### PR TITLE
Add support for Plasma 6

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -1,5 +1,17 @@
-workspace.clientDemandsAttentionChanged.connect((client, set) => {
-    if (set) {
-        workspace.activeClient = client;
-    }
-});
+if (workspace.windowList) {
+    //KWin 6
+    workspace.windowAdded.connect(function(win) {
+        win.demandsAttentionChanged.connect(function() {
+            if (win.demandsAttention) {
+                workspace.activeWindow = win;
+            }
+        })
+    });
+} else {
+    //KWin 5
+    workspace.clientDemandsAttentionChanged.connect((client, set) => {
+        if (set) {
+            workspace.activeClient = client;
+        }
+    });
+}

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
             }
         ],
         "Id": "focusonattentionrequest",
-        "Version": "1.0",
+        "Version": "2.0",
         "License": "MIT",
         "Website": "https://github.com/stepan-tikunov/kwinscript-focus-when-attention-required"
     },


### PR DESCRIPTION
With the release of Plasma 6, there is no longer any direct equivalent of `clientDemandsAttentionChanged` in the workspace object. Instead, we have to watch for window creation, and hook the `demandsAttention` event there for each window. From there, it works basically the same as before.

The Plasma 5 implementation remains the same as before, the script now starts by detecting which version it is running on.